### PR TITLE
Remove query presets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,10 +8,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['es2015', 'react']
-        }
+        loader: 'babel-loader'
       },
     ]
   }


### PR DESCRIPTION
`es6` and `react` presets in Webpack query params are not necessary anymore since these are already defined in `.babelrc`.
